### PR TITLE
fix(providers): handle codex tool_call item events silently

### DIFF
--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -303,6 +303,27 @@ func TestCommandAndReasoningEventsAppearInTranscript(t *testing.T) {
 	}
 }
 
+func TestToolCallEventAppearsInTranscript(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(nil, config.Default())
+	s := m.createSession("demo")
+	m.ActiveSessionID = s.ID
+	m.Width = 100
+	m.Height = 24
+
+	m.handleProviderEvent(providers.Event{
+		Type:      providers.EventToolCall,
+		SessionID: s.ID,
+		Text:      "patched files",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "[tool-call] patched files") {
+		t.Fatalf("expected transcript to contain tool-call line, got: %s", view)
+	}
+}
+
 func TestViewFitsConfiguredHeight(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/chat/engine.go
+++ b/internal/core/chat/engine.go
@@ -660,6 +660,16 @@ func (e *Engine) HandleProviderEvent(ev providers.Event) {
 			e.Store.AddAssistantMessage(s.ID, text)
 		}
 		e.runDevelopmentWorkCompleteHooksForContent(s, ev.Text)
+	case providers.EventToolCall:
+		content := "[tool-call]"
+		if text := strings.TrimSpace(ev.Text); text != "" {
+			content = "[tool-call] " + text
+		}
+		if strings.TrimSpace(ev.ItemID) != "" {
+			e.upsertItemMessage(s.ID, ev.RequestID, ev.ItemID, content)
+		} else {
+			e.Store.AddAssistantMessage(s.ID, content)
+		}
 	case providers.EventCommandExecution:
 		e.handleCommandExecutionEvent(s.ID, ev)
 	case providers.EventTurnUsage:

--- a/internal/core/chat/engine_test.go
+++ b/internal/core/chat/engine_test.go
@@ -755,6 +755,74 @@ func TestHandleProviderReasoningUpsertsByItemID(t *testing.T) {
 	}
 }
 
+func TestHandleProviderToolCallRendersConciseLine(t *testing.T) {
+	store := session.NewStore()
+	s := store.CreateSession("demo")
+	eng := NewEngine(store, &fakeManager{events: make(chan providers.Event)}, config.Default())
+
+	eng.HandleProviderEvent(providers.Event{
+		Type:      providers.EventToolCall,
+		SessionID: s.ID,
+		ItemID:    "item-tc",
+		Text:      "patched files",
+	})
+
+	msgs := store.ActiveSession().Messages
+	if len(msgs) != 1 {
+		t.Fatalf("expected one tool-call message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "[tool-call] patched files" {
+		t.Fatalf("unexpected tool-call content: %q", msgs[0].Content)
+	}
+}
+
+func TestHandleProviderToolCallEmptyText(t *testing.T) {
+	store := session.NewStore()
+	s := store.CreateSession("demo")
+	eng := NewEngine(store, &fakeManager{events: make(chan providers.Event)}, config.Default())
+
+	eng.HandleProviderEvent(providers.Event{
+		Type:      providers.EventToolCall,
+		SessionID: s.ID,
+		ItemID:    "item-tc",
+	})
+
+	msgs := store.ActiveSession().Messages
+	if len(msgs) != 1 {
+		t.Fatalf("expected one tool-call message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "[tool-call]" {
+		t.Fatalf("unexpected tool-call content: %q", msgs[0].Content)
+	}
+}
+
+func TestHandleProviderToolCallUpsertsByItemID(t *testing.T) {
+	store := session.NewStore()
+	s := store.CreateSession("demo")
+	eng := NewEngine(store, &fakeManager{events: make(chan providers.Event)}, config.Default())
+
+	eng.HandleProviderEvent(providers.Event{
+		Type:      providers.EventToolCall,
+		SessionID: s.ID,
+		ItemID:    "item-tc",
+		Text:      "apply_patch",
+	})
+	eng.HandleProviderEvent(providers.Event{
+		Type:      providers.EventToolCall,
+		SessionID: s.ID,
+		ItemID:    "item-tc",
+		Text:      "patched files",
+	})
+
+	msgs := store.ActiveSession().Messages
+	if len(msgs) != 1 {
+		t.Fatalf("expected one upserted tool-call message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "[tool-call] patched files" {
+		t.Fatalf("expected latest tool-call text, got %q", msgs[0].Content)
+	}
+}
+
 func TestHandleProviderAgentMessageClearsPendingPlaceholderAndUsesItemID(t *testing.T) {
 	store := session.NewStore()
 	s := store.CreateSession("demo")

--- a/internal/providers/codex_adapter.go
+++ b/internal/providers/codex_adapter.go
@@ -659,9 +659,16 @@ func normalizeCodexEvent(ev codexJSONEvent, raw map[string]any) (Event, bool) {
 				}, true
 			}
 			return Event{}, true
+		case "tool_call":
+			return Event{
+				Type:     EventToolCall,
+				ItemType: itemType,
+				ItemID:   itemID,
+				Text:     firstNonEmptyString(item, "text", "name", "tool_name"),
+			}, true
 		default:
-			// Some item lifecycle entries are internal-only (for example tool_call)
-			// and should not be surfaced as unknown provider events.
+			// Some item lifecycle entries are internal-only and should not
+			// be surfaced as unknown provider events.
 			return Event{}, true
 		}
 	default:
@@ -723,6 +730,15 @@ func findFirstString(v any, keys ...string) string {
 			if s := findFirstString(item, keys...); s != "" {
 				return s
 			}
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyString(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if s, ok := m[key].(string); ok && strings.TrimSpace(s) != "" {
+			return strings.TrimSpace(s)
 		}
 	}
 	return ""

--- a/internal/providers/codex_adapter.go
+++ b/internal/providers/codex_adapter.go
@@ -660,7 +660,9 @@ func normalizeCodexEvent(ev codexJSONEvent, raw map[string]any) (Event, bool) {
 			}
 			return Event{}, true
 		default:
-			return Event{}, false
+			// Some item lifecycle entries are internal-only (for example tool_call)
+			// and should not be surfaced as unknown provider events.
+			return Event{}, true
 		}
 	default:
 		return Event{}, false

--- a/internal/providers/codex_adapter.go
+++ b/internal/providers/codex_adapter.go
@@ -667,9 +667,7 @@ func normalizeCodexEvent(ev codexJSONEvent, raw map[string]any) (Event, bool) {
 				Text:     firstNonEmptyString(item, "text", "name", "tool_name"),
 			}, true
 		default:
-			// Some item lifecycle entries are internal-only and should not
-			// be surfaced as unknown provider events.
-			return Event{}, true
+			return Event{}, false
 		}
 	default:
 		return Event{}, false

--- a/internal/providers/codex_adapter_test.go
+++ b/internal/providers/codex_adapter_test.go
@@ -290,7 +290,7 @@ func TestCodexAdapterFailureFallsBackToStderrMessage(t *testing.T) {
 func TestCodexAdapterEmitsUnknownEventsAndLogsPayload(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "provider-debug.log")
 	t.Setenv("OPEN_PILOT_PROVIDER_DEBUG_LOG", logPath)
-	env := setupFakeCodex(t, "unknown_event", "thread-unknown", "hello")
+	env := setupFakeCodex(t, "unknown_raw_event", "thread-unknown", "hello")
 
 	adapter := newCodexCLIAdapter(env.binary).(*codexCLIAdapter)
 	handle, events := startHandle(t, adapter, env.repoDir)
@@ -300,10 +300,10 @@ func TestCodexAdapterEmitsUnknownEventsAndLogsPayload(t *testing.T) {
 	}
 
 	unknown := waitEventType(t, events, EventUnknown)
-	if unknown.RawType != "item.completed" {
-		t.Fatalf("expected unknown raw type item.completed, got %q", unknown.RawType)
+	if unknown.RawType != "tool.preview" {
+		t.Fatalf("expected unknown raw type tool.preview, got %q", unknown.RawType)
 	}
-	if !strings.Contains(unknown.RawJSON, `"item":{"type":"tool_call"`) {
+	if !strings.Contains(unknown.RawJSON, `"type":"tool.preview"`) {
 		t.Fatalf("expected raw json payload, got %q", unknown.RawJSON)
 	}
 	_ = waitEventType(t, events, EventFinal)
@@ -312,8 +312,41 @@ func TestCodexAdapterEmitsUnknownEventsAndLogsPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read provider debug log failed: %v", err)
 	}
-	if !strings.Contains(string(data), `"raw_type":"item.completed"`) {
+	if !strings.Contains(string(data), `"raw_type":"tool.preview"`) {
 		t.Fatalf("expected unknown event diagnostic in log, got %q", string(data))
+	}
+}
+
+func TestCodexAdapterIgnoresToolCallItemCompleted(t *testing.T) {
+	env := setupFakeCodex(t, "unknown_event", "thread-unknown", "hello")
+
+	adapter := newCodexCLIAdapter(env.binary).(*codexCLIAdapter)
+	handle, events := startHandle(t, adapter, env.repoDir)
+
+	if err := adapter.Send(context.Background(), handle, PromptRequest{ID: "req-tool-call", SessionID: "sess-1", RepoPath: env.repoDir, Text: "hello"}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	timer := time.NewTimer(providerEventWaitTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			t.Fatalf("timed out waiting for final event")
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatalf("event channel closed before final")
+			}
+			if ev.Type == EventUnknown {
+				t.Fatalf("expected tool_call item.completed to be handled, got unknown event: %#v", ev)
+			}
+			if ev.Type == EventFinal {
+				return
+			}
+			if ev.Type == EventError {
+				t.Fatalf("unexpected provider error: %#v", ev)
+			}
+		}
 	}
 }
 
@@ -450,6 +483,13 @@ fi
 if [ "$mode" = "unknown_event" ]; then
   printf '{"type":"thread.started","thread_id":"%s"}\n' "$thread_id"
   printf '{"type":"item.completed","item":{"type":"tool_call","text":"patched files"}}\n'
+  printf '{"type":"response.output_text.delta","delta":"%s"}\n' "$last_message"
+  printf '%s' "$last_message" > "$out_file"
+  exit 0
+fi
+if [ "$mode" = "unknown_raw_event" ]; then
+  printf '{"type":"thread.started","thread_id":"%s"}\n' "$thread_id"
+  printf '{"type":"tool.preview","text":"still unknown"}\n'
   printf '{"type":"response.output_text.delta","delta":"%s"}\n' "$last_message"
   printf '%s' "$last_message" > "$out_file"
   exit 0

--- a/internal/providers/codex_adapter_test.go
+++ b/internal/providers/codex_adapter_test.go
@@ -329,6 +329,7 @@ func TestCodexAdapterIgnoresToolCallItemCompleted(t *testing.T) {
 
 	timer := time.NewTimer(providerEventWaitTimeout)
 	defer timer.Stop()
+	sawToolCall := false
 	for {
 		select {
 		case <-timer.C:
@@ -340,7 +341,16 @@ func TestCodexAdapterIgnoresToolCallItemCompleted(t *testing.T) {
 			if ev.Type == EventUnknown {
 				t.Fatalf("expected tool_call item.completed to be handled, got unknown event: %#v", ev)
 			}
+			if ev.Type == EventToolCall {
+				sawToolCall = true
+				if ev.Text != "patched files" {
+					t.Fatalf("expected tool_call text, got %#v", ev)
+				}
+			}
 			if ev.Type == EventFinal {
+				if !sawToolCall {
+					t.Fatalf("expected tool_call event before final")
+				}
 				return
 			}
 			if ev.Type == EventError {

--- a/internal/providers/codex_session_test.go
+++ b/internal/providers/codex_session_test.go
@@ -173,7 +173,7 @@ func TestNormalizeCodexEventAgentMessage(t *testing.T) {
 	}
 }
 
-func TestNormalizeCodexEventUnknownItemSubtypeIsHandledSilently(t *testing.T) {
+func TestNormalizeCodexEventToolCall(t *testing.T) {
 	t.Parallel()
 
 	ev := codexJSONEvent{Type: "item.completed"}
@@ -187,10 +187,53 @@ func TestNormalizeCodexEventUnknownItemSubtypeIsHandledSilently(t *testing.T) {
 	}
 	got, ok := normalizeCodexEvent(ev, raw)
 	if !ok {
-		t.Fatalf("expected unknown item subtype to be marked handled")
+		t.Fatalf("expected tool_call normalization")
 	}
-	if got.Type != "" {
-		t.Fatalf("expected no normalized event for internal-only item subtype, got %#v", got)
+	if got.Type != EventToolCall || got.ItemType != "tool_call" || got.ItemID != "item-4" || got.Text != "patched files" {
+		t.Fatalf("unexpected tool_call normalized event: %#v", got)
+	}
+}
+
+func TestNormalizeCodexEventToolCallTextFallback(t *testing.T) {
+	t.Parallel()
+
+	ev := codexJSONEvent{Type: "item.completed"}
+	rawName := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":   "item-5",
+			"type": "tool_call",
+			"name": "apply_patch",
+		},
+	}
+	got, ok := normalizeCodexEvent(ev, rawName)
+	if !ok || got.Type != EventToolCall || got.Text != "apply_patch" {
+		t.Fatalf("expected tool_call text fallback from name, got %#v ok=%v", got, ok)
+	}
+
+	rawToolName := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":        "item-6",
+			"type":      "tool_call",
+			"tool_name": "exec_command",
+		},
+	}
+	got, ok = normalizeCodexEvent(ev, rawToolName)
+	if !ok || got.Type != EventToolCall || got.Text != "exec_command" {
+		t.Fatalf("expected tool_call text fallback from tool_name, got %#v ok=%v", got, ok)
+	}
+
+	rawEmpty := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":   "item-7",
+			"type": "tool_call",
+		},
+	}
+	got, ok = normalizeCodexEvent(ev, rawEmpty)
+	if !ok || got.Type != EventToolCall || got.Text != "" {
+		t.Fatalf("expected empty tool_call text fallback, got %#v ok=%v", got, ok)
 	}
 }
 

--- a/internal/providers/codex_session_test.go
+++ b/internal/providers/codex_session_test.go
@@ -237,6 +237,24 @@ func TestNormalizeCodexEventToolCallTextFallback(t *testing.T) {
 	}
 }
 
+func TestNormalizeCodexEventUnknownItemSubtypeIsUnknown(t *testing.T) {
+	t.Parallel()
+
+	ev := codexJSONEvent{Type: "item.completed"}
+	raw := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":   "item-unknown",
+			"type": "totally_new_item_type",
+			"text": "new payload",
+		},
+	}
+	got, ok := normalizeCodexEvent(ev, raw)
+	if ok {
+		t.Fatalf("expected unknown item subtype to return ok=false, got %#v", got)
+	}
+}
+
 func TestNormalizeCodexEventTurnUsage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/codex_session_test.go
+++ b/internal/providers/codex_session_test.go
@@ -173,6 +173,27 @@ func TestNormalizeCodexEventAgentMessage(t *testing.T) {
 	}
 }
 
+func TestNormalizeCodexEventUnknownItemSubtypeIsHandledSilently(t *testing.T) {
+	t.Parallel()
+
+	ev := codexJSONEvent{Type: "item.completed"}
+	raw := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":   "item-4",
+			"type": "tool_call",
+			"text": "patched files",
+		},
+	}
+	got, ok := normalizeCodexEvent(ev, raw)
+	if !ok {
+		t.Fatalf("expected unknown item subtype to be marked handled")
+	}
+	if got.Type != "" {
+		t.Fatalf("expected no normalized event for internal-only item subtype, got %#v", got)
+	}
+}
+
 func TestNormalizeCodexEventTurnUsage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/events.go
+++ b/internal/providers/events.go
@@ -13,6 +13,7 @@ const (
 	EventReasoning        = "reasoning"
 	EventCommandExecution = "command_execution"
 	EventAgentMessage     = "agent_message"
+	EventToolCall         = "tool_call"
 	EventTurnUsage        = "turn.usage"
 )
 
@@ -70,7 +71,7 @@ func parseWrapperEvent(line []byte) (Event, error) {
 
 func isKnownEventType(eventType string) bool {
 	switch eventType {
-	case EventReady, EventChunk, EventFinal, EventError, EventStatus, EventExited, EventReasoning, EventCommandExecution, EventAgentMessage, EventTurnUsage:
+	case EventReady, EventChunk, EventFinal, EventError, EventStatus, EventExited, EventReasoning, EventCommandExecution, EventAgentMessage, EventToolCall, EventTurnUsage:
 		return true
 	default:
 		return false

--- a/internal/providers/events_test.go
+++ b/internal/providers/events_test.go
@@ -41,3 +41,11 @@ func TestParseWrapperEventUnknownType(t *testing.T) {
 		t.Fatalf("expected raw json to be preserved")
 	}
 }
+
+func TestIsKnownEventTypeIncludesToolCall(t *testing.T) {
+	t.Parallel()
+
+	if !isKnownEventType("tool_call") {
+		t.Fatalf("expected tool_call to be recognized as known event type")
+	}
+}


### PR DESCRIPTION
Treat unknown item subtypes within item.started/item.completed as handled internal lifecycle events so they do not surface as unhandled provider events. Add regression tests for tool_call item.completed and preserve unknown raw event diagnostics with a truly unknown type.

#8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-call messages are now surfaced in chat transcripts as concise "[tool-call]" entries with optional text and are integrated into the message stream.

* **Bug Fixes**
  * Completed internal tool events no longer surface as unknown events or spurious diagnostics; they are filtered appropriately while preserving relevant final events.

* **Tests**
  * Expanded coverage for tool-call normalization, transcript rendering, text fallbacks, upsert/dedup behavior, and event recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->